### PR TITLE
Update with up to date patches from upstream PRs

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5660,6 +5660,7 @@ namespace bgfx { namespace gl
 						else
 						{
 							bx::write(&writer, "#define texture2DArrayLodEXT texture2DArrayLod\n");
+							bx::write(&writer, "#define textureArray texture\n");
 						}
 					}
 

--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -125,6 +125,17 @@ namespace bgfx { namespace glsl
 						continue;
 					}
 
+					if (0 == bx::strCmp(qualifier, "flat", 4)
+					||  0 == bx::strCmp(qualifier, "smooth", 6)
+					||  0 == bx::strCmp(qualifier, "noperspective", 13)
+					||  0 == bx::strCmp(qualifier, "centroid", 8)
+					   )
+					{
+						// skip interpolation qualifiers
+						parse.set(eol.getPtr() + 1, parse.getTerm() );
+						continue;
+					}
+
 					if (0 == bx::strCmp(parse, "tmpvar", 6) )
 					{
 						// skip temporaries


### PR DESCRIPTION
This is not a merge request but rather a reset request.

Please test and reset master to this branch.

This branch is rebased on upstream master with fixes from 

* https://github.com/bwrsandman/bgfx/tree/texture_array_flat (shaderc for `flat` keyword)
* https://github.com/bwrsandman/bgfx/tree/instance_bind_index_offset_change replacing https://github.com/bkaradzic/bgfx/commit/1cfffa6a42d743728957338e197e41d8e5e698f3#diff-340d0d905e5ed42ff107c56c3082918a for our instancing bug

After the reset, the master branch should have two commits ahead of upstream
```
d24077d19 shaderc_glsl: Fix error when mixing SamplerArray and `flat` keyword
198471432 shaderc_glsl: skip interp params when parsing glslopt output
```