### PR TITLE
shaderc_glsl: parse int samplers like float samplers

### DIFF
--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -165,7 +165,9 @@ namespace bgfx { namespace glsl
 
 					char uniformType[256];
 
-					if (0 == bx::strCmp(typen, "sampler", 7) )
+					if (0 == bx::strCmp(typen, "sampler", 7)
+					||  0 == bx::strCmp(typen, "isampler", 8)
+					||  0 == bx::strCmp(typen, "usampler", 8) )
 					{
 						bx::strCopy(uniformType, BX_COUNTOF(uniformType), "int");
 					}


### PR DESCRIPTION
upstream PR: https://github.com/bkaradzic/bgfx/pull/2341
Fixes loading a shaderc shader using `USAMPLER2D`

```
bgfx: bgfx\src\renderer_gl.cpp:4939: BGFX Sampler #1 at location 1.
bgfx: bgfx\src\renderer_gl.cpp:4967: BGFX WARN User defined uniform 's1_countryMap' is not found, it won't be set.
bgfx: bgfx\src\renderer_gl.cpp:4990: BGFX      uniform GL_UNSIGNED_INT_SAMPLER_2D s1_countryMap is at location 1, size 1, offset 0
```
When investigating the output of shaderc, the uniform count does not include the `usampler`.